### PR TITLE
Remove address scoping from the list of host instruction constraints.

### DIFF
--- a/draft-ietf-dnssd-srp.xml
+++ b/draft-ietf-dnssd-srp.xml
@@ -508,11 +508,6 @@
 	      <li>
 		one or more "Add to an RRset" RRs of type A and/or AAAA,</li>
 	      <li>
-		A and/or AAAA records must be of sufficient scope to be reachable by all hosts that
-		might query the DNS. If a link-scope address or IPv4 autoconfiguration address is provided
-		by the SRP client, the SRP server MUST treat this as if no address records were received;
-		that is, the Host Description is not valid.</li>
-	      <li>
 		exactly one "Add to an RRset" RR that adds a KEY RR that contains the public key corresponding to the private key
 		that was used to sign the message,</li>
 	      <li>
@@ -521,6 +516,16 @@
 	      <li>
 		Host Description Instructions do not modify any other resource records.</li>
             </ul>
+	    <t>
+	      A and/or AAAA records that are not of of sufficient scope to be validly published in a DNS zone can be ignored by the
+	      SRP server, which could result in a host description effectively containing zero reachable addresses even when it
+	      contains one or more addresses.</t>
+
+	    <t>
+	      For example, if a link-scope address or IPv4 autoconfiguration address is provided by the SRP requestor, the SRP
+	      registrar could not publish this in a DNS zone. However, in some situations, the SRP registrar may make the records
+	      available through a mechanism such as an advertising proxy only on the specific link from which the SRP update
+	      originated; in such a situation, locally-scoped records are still valid.</t>
 	  </section>
 	</section>
 


### PR DESCRIPTION
The set of constraints for the host description includes a constrain that A and AAAA records must be of sufficient scope. This is asking a bit much of the SRP server, which may or may not be able to make this determination. There may also be cases where an SRP registration with an address of less than global scope is useful. Consequently, this constraint is removed, and text added to talk about how servers should deal with addresses of less-than-global scope.