### PR TITLE
Update IANA considerations per David Schinazi.

### DIFF
--- a/draft-ietf-dnssd-srp.xml
+++ b/draft-ietf-dnssd-srp.xml
@@ -817,6 +817,16 @@
 	<name>Subdomains of 'service.arpa.'</name>
 	<t>This document only makes use of the 'default.service.arpa' subdomain of 'service.arpa.' Other subdomains are reserved
 	  for future use by DNS-SD or related work. The IANA is requested to create a registry, the "service.arpa Subdomain Registry".
+          The IETF shall have change control for this registry. New entries may be added either as a result of Standards Action
+	  <xref target="RFC8126" section="4.9"/> or with IESG approval <xref target="RFC 8126" section=4.10"/>, provided that a
+	  specification exists <xref target="RFC8126" section="4.6"/>.
+	</t>
+        <t>
+	  The IANA shall group the "service.arpa Subdomain Registry" with the "Locally-Served DNS Zones" registry.
+          The registry shall be a table with three columns: the subdomain name (expressed as a fully-qualified domain
+	  name), a brief description of how it is used, and a reference to the document that describes its use in detail.
+	</t>
+	<t>
 	  This registry shall begin as the following table:
 	</t>
 	<table>
@@ -829,7 +839,7 @@
 	  </thead>
 	  <tbody>
 	    <tr>
-	      <td>default</td>
+	      <td>default.service.arpa.</td>
 	      <td>Default domain for SRP updates</td>
 	      <td>[THIS DOCUMENT]</td>
 	    </tr>
@@ -935,6 +945,7 @@
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3596.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6763.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7858.xml" />
+      <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8126.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8375.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8624.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8765.xml" />


### PR DESCRIPTION
David Schinazi pointed out:

> I noticed this during my shepherd review. Section [8.2](https://www.ietf.org/archive/id/draft-ietf-dnssd-srp-16.html#section-8.2) creates a new registry but is lacking sufficient information for IANA to create the registry. In particular, the registration procedure is missing. Please refer to RFC 8126 for guidance.

This PR implements David's suggestion.