### PR TITLE
Make some normative references informative, per David Schinazi.

### DIFF
--- a/draft-ietf-dnssd-srp.xml
+++ b/draft-ietf-dnssd-srp.xml
@@ -938,27 +938,6 @@
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8375.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8624.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8765.xml" />
-      <reference anchor="SUDN" target="https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml">
-        <front>
-          <title>Special-Use Domain Names Registry</title>
-          <author/>
-          <date month="July" year="2012"/>
-        </front>
-      </reference>
-      <reference anchor="LSDZ" target="https://www.iana.org/assignments/locally-served-dns-zones/locally-served-dns-zones.xhtml">
-        <front>
-          <title>Locally-Served DNS Zones Registry</title>
-          <author/>
-          <date month="July" year="2011"/>
-        </front>
-      </reference>
-      <reference anchor="IAB-ARPA" target="https://www.iab.org/documents/correspondence-reports-documents/2017-2/iab-statement-on-the-registration-of-special-use-names-in-the-arpa-domain/">
-        <front>
-          <title>Internet Architecture Board statement on the registration of special use names in the ARPA domain</title>
-          <author/>
-          <date month="March" year="2017"/>
-        </front>
-      </reference>
     </references>
 
     <references>
@@ -976,6 +955,30 @@
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8945.xml" />
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.cheshire-dnssd-roadmap.xml"/>
       <xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-dnssd-advertising-proxy.xml"/>
+
+      <reference anchor="SUDN" target="https://www.iana.org/assignments/special-use-domain-names/special-use-domain-names.xhtml">
+        <front>
+          <title>Special-Use Domain Names Registry</title>
+          <author/>
+          <date month="July" year="2012"/>
+        </front>
+      </reference>
+
+      <reference anchor="LSDZ" target="https://www.iana.org/assignments/locally-served-dns-zones/locally-served-dns-zones.xhtml">
+        <front>
+          <title>Locally-Served DNS Zones Registry</title>
+          <author/>
+          <date month="July" year="2011"/>
+        </front>
+      </reference>
+
+      <reference anchor="IAB-ARPA" target="https://www.iab.org/documents/correspondence-reports-documents/2017-2/iab-statement-on-the-registration-of-special-use-names-in-the-arpa-domain/">
+        <front>
+          <title>Internet Architecture Board statement on the registration of special use names in the ARPA domain</title>
+          <author/>
+          <date month="March" year="2017"/>
+        </front>
+      </reference>
 
       <reference anchor="ZC">
         <front>


### PR DESCRIPTION
David Schinazi wrote:

> As is tradition over here at IETF, I must ask you to change the following normative references to informative. Please forgive me as I channel the spirits of our forefathers and their great wisdom captured in RFC 3986 and 4897.
> 
> - SUDN
> - LSDZ
> - IAB-ARPA
> 
> The first two are just pointers to the current URL of the IANA registry, and as such do not need to be normative. The third can be made informative since we already have a normative reference to RFC 3172.